### PR TITLE
Strict Liquid Syntax (Part 2) + Render Performance (#441)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-﻿# Build script for dotliquid, see https://www.appveyor.com/docs/appveyor-yml for reference
-version: 2.1.{build}
+# Build script for dotliquid, see https://www.appveyor.com/docs/appveyor-yml for reference
+version: 2.2.{build}
 image: Visual Studio 2017
 
 cache:

--- a/src/DotLiquid.Tests/ExtendedFilterTests.cs
+++ b/src/DotLiquid.Tests/ExtendedFilterTests.cs
@@ -1,0 +1,51 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotLiquid.Tests
+{
+    [TestFixture]
+    public class ExtendedFilterTests
+    {
+        private Context _context;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _context = new Context(CultureInfo.InvariantCulture);
+            Template.RegisterFilter(typeof(ExtendedFilters));
+        }
+
+        [Test]
+        public void TestTitleize()
+        {
+            var context = _context;
+            Assert.AreEqual(null, ExtendedFilters.Titleize(context: context, input: null));
+            Assert.AreEqual("", ExtendedFilters.Titleize(context: context, input: ""));
+            Assert.AreEqual(" ", ExtendedFilters.Titleize(context: context, input: " "));
+            Assert.AreEqual("That Is One Sentence.", ExtendedFilters.Titleize(context: context, input: "That is one sentence."));
+
+            Helper.AssertTemplateResult(
+                expected: "Title",
+                template: "{{ 'title' | titleize }}");
+        }
+
+        [Test]
+        public void TestUpcaseFirst()
+        {
+            var context = _context;
+            Assert.AreEqual(null, ExtendedFilters.UpcaseFirst(context: context, input: null));
+            Assert.AreEqual("", ExtendedFilters.UpcaseFirst(context: context, input: ""));
+            Assert.AreEqual(" ", ExtendedFilters.UpcaseFirst(context: context, input: " "));
+            Assert.AreEqual(" My boss is Mr. Doe.", ExtendedFilters.UpcaseFirst(context: context, input: " my boss is Mr. Doe."));
+
+            Helper.AssertTemplateResult(
+                expected: "My great title",
+                template: "{{ 'my great title' | upcase_first }}");
+        }
+    }
+}

--- a/src/DotLiquid.Tests/HashTests.cs
+++ b/src/DotLiquid.Tests/HashTests.cs
@@ -126,9 +126,8 @@ namespace DotLiquid.Tests
             var hash = new Hash(0); // default value of zero
             hash["key"] = "value";
 
-            // NOTE: the next two asserts will change to true when performance changes are introduced by PR #441.
-            Assert.False(hash.Contains("unknown-key"));
-            Assert.False(hash.ContainsKey("unknown-key"));
+            Assert.True(hash.Contains("unknown-key"));
+            Assert.True(hash.ContainsKey("unknown-key"));
             Assert.AreEqual(0, hash["unknown-key"]); // ensure the default value is returned
 
             Assert.True(hash.Contains("key"));
@@ -136,8 +135,8 @@ namespace DotLiquid.Tests
             Assert.AreEqual("value", hash["key"]);
 
             hash.Remove("key");
-            Assert.False(hash.Contains("key"));
-            Assert.False(hash.ContainsKey("key"));
+            Assert.True(hash.Contains("key"));
+            Assert.True(hash.ContainsKey("key"));
             Assert.AreEqual(0, hash["key"]); // ensure the default value is returned after key removed
         }
 
@@ -147,8 +146,8 @@ namespace DotLiquid.Tests
             var hash = new Hash((h, k) => { return "Lambda Value"; });
             hash["key"] = "value";
 
-            Assert.False(hash.Contains("unknown-key"));
-            Assert.False(hash.ContainsKey("unknown-key"));
+            Assert.True(hash.Contains("unknown-key"));
+            Assert.True(hash.ContainsKey("unknown-key"));
             Assert.AreEqual("Lambda Value", hash["unknown-key"]);
 
             Assert.True(hash.Contains("key"));

--- a/src/DotLiquid.Tests/RegexpTests.cs
+++ b/src/DotLiquid.Tests/RegexpTests.cs
@@ -81,17 +81,6 @@ namespace DotLiquid.Tests
             CollectionAssert.AreEqual(new[] { "arg1", "arg2", "\"arg 3\"", "arg4" }, Run("arg1 arg2 \"arg 3\" arg4", Liquid.QuotedFragment));
         }
 
-        [Test]
-        public void TestVariableParser()
-        {
-            CollectionAssert.AreEqual(new[] { "var" }, Run("var", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "method" }, Run("var.method", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[method]" }, Run("var[method]", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]" }, Run("var[method][0]", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[\"method\"]", "[0]" }, Run("var[\"method\"][0]", Liquid.VariableParser));
-            CollectionAssert.AreEqual(new[] { "var", "[method]", "[0]", "method" }, Run("var[method][0].method", Liquid.VariableParser));
-        }
-
         private static List<string> Run(string input, string pattern)
         {
             return R.Scan(input, new Regex(pattern));

--- a/src/DotLiquid.Tests/StandardFilterTests.cs
+++ b/src/DotLiquid.Tests/StandardFilterTests.cs
@@ -12,6 +12,7 @@ namespace DotLiquid.Tests
     {
         private Context _contextV20;
         private Context _contextV21;
+        private Context _contextV22;
 
         [OneTimeSetUp]
         public void SetUp()
@@ -23,6 +24,10 @@ namespace DotLiquid.Tests
             _contextV21 = new Context(CultureInfo.InvariantCulture)
             {
                 SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid21
+            };
+            _contextV22 = new Context(CultureInfo.InvariantCulture)
+            {
+                SyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid22
             };
         }
 
@@ -200,27 +205,87 @@ namespace DotLiquid.Tests
         }
 
         [Test]
-        public void TestSort()
+        public void TestSortV20()
         {
-            Assert.AreEqual(null, StandardFilters.Sort(null));
-            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Sort(new string[] { }));
-            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4 }, StandardFilters.Sort(new[] { 4, 3, 2, 1 }));
-            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 4 } },
-                StandardFilters.Sort(new[] { new { a = 4 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+            var ints = new[] { 10, 3, 2, 1 };
+            Assert.AreEqual(null, StandardFilters.Sort(_contextV20, null));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Sort(_contextV20, new string[] { }));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 10 }, StandardFilters.Sort(_contextV20, ints));
+            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 10 } },
+                StandardFilters.Sort(_contextV20, new[] { new { a = 10 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+
+            // Issue #393 - Incorrect (Case-Insensitve) Alphabetic Sort
+            var strings = new[] { "zebra", "octopus", "giraffe", "Sally Snake" };
+            CollectionAssert.AreEqual(new[] { "giraffe", "octopus", "Sally Snake", "zebra" },
+                StandardFilters.Sort(_contextV20, strings));
+
+            var hashes = new List<Hash>();
+            for (var i = 0; i < strings.Length; i++)
+                hashes.Add(CreateHash(ints[i], strings[i]));
+            CollectionAssert.AreEqual(new[] { hashes[2], hashes[1], hashes[3], hashes[0] },
+                StandardFilters.Sort(_contextV20, hashes, "content"));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0] },
+                StandardFilters.Sort(_contextV20, hashes, "sortby"));
+        }
+
+        [Test]
+        public void TestSortV22()
+        {
+            var ints = new[] { 10, 3, 2, 1 };
+            Assert.AreEqual(null, StandardFilters.Sort(_contextV22, null));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.Sort(_contextV22, new string[] { }));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 10 }, StandardFilters.Sort(_contextV22, ints));
+            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 10 } },
+                StandardFilters.Sort(_contextV22, new[] { new { a = 10 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+
+            var strings = new[] { "zebra", "octopus", "giraffe", "Sally Snake" };
+            CollectionAssert.AreEqual(new[] { "Sally Snake", "giraffe", "octopus", "zebra" },
+                StandardFilters.Sort(_contextV22, strings));
+
+            var hashes = new List<Hash>();
+            for (var i = 0; i < strings.Length; i++)
+                hashes.Add(CreateHash(ints[i], strings[i]));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0]  },
+                StandardFilters.Sort(_contextV22, hashes, "content"));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0] },
+                StandardFilters.Sort(_contextV22, hashes, "sortby"));
+        }
+
+        [Test]
+        public void TestSortNatural()
+        {
+            var ints = new[] { 10, 3, 2, 1 };
+            Assert.AreEqual(null, StandardFilters.SortNatural(null));
+            CollectionAssert.AreEqual(new string[] { }, StandardFilters.SortNatural(new string[] { }));
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 10 }, StandardFilters.SortNatural(ints));
+            CollectionAssert.AreEqual(new[] { new { a = 1 }, new { a = 2 }, new { a = 3 }, new { a = 10 } },
+                StandardFilters.SortNatural(new[] { new { a = 10 }, new { a = 3 }, new { a = 1 }, new { a = 2 } }, "a"));
+
+            var strings = new[] { "zebra", "octopus", "giraffe", "Sally Snake" };
+            CollectionAssert.AreEqual(new[] { "giraffe", "octopus", "Sally Snake", "zebra" },
+                StandardFilters.SortNatural(strings));
+
+            var hashes = new List<Hash>();
+            for (var i = 0; i < strings.Length; i++)
+                hashes.Add(CreateHash(ints[i], strings[i]));
+            CollectionAssert.AreEqual(new[] { hashes[2], hashes[1], hashes[3], hashes[0] },
+                StandardFilters.SortNatural(hashes, "content"));
+            CollectionAssert.AreEqual(new[] { hashes[3], hashes[2], hashes[1], hashes[0] },
+                StandardFilters.SortNatural(hashes, "sortby"));
         }
 
         [Test]
         public void TestSort_OnHashList_WithProperty_DoesNotFlattenList()
         {
             var list = new List<Hash>();
-            var hash1 = CreateHash("1", "Text1");
-            var hash2 = CreateHash("2", "Text2");
-            var hash3 = CreateHash("3", "Text3");
+            var hash1 = CreateHash(1, "Text1");
+            var hash2 = CreateHash(2, "Text2");
+            var hash3 = CreateHash(3, "Text3");
             list.Add(hash3);
             list.Add(hash1);
             list.Add(hash2);
 
-            var result = StandardFilters.Sort(list, "sortby").Cast<Hash>().ToArray();
+            var result = StandardFilters.Sort(_contextV20, list, "sortby").Cast<Hash>().ToArray();
             Assert.AreEqual(3, result.Count());
             Assert.AreEqual(hash1["content"], result[0]["content"]);
             Assert.AreEqual(hash2["content"], result[1]["content"]);
@@ -231,22 +296,22 @@ namespace DotLiquid.Tests
         public void TestSort_OnDictionaryWithPropertyOnlyInSomeElement_ReturnsSortedDictionary()
         {
             var list = new List<Hash>();
-            var hash1 = CreateHash("1", "Text1");
-            var hash2 = CreateHash("2", "Text2");
+            var hash1 = CreateHash(1, "Text1");
+            var hash2 = CreateHash(2, "Text2");
             var hashWithNoSortByProperty = new Hash();
             hashWithNoSortByProperty.Add("content", "Text 3");
             list.Add(hash2);
             list.Add(hashWithNoSortByProperty);
             list.Add(hash1);
 
-            var result = StandardFilters.Sort(list, "sortby").Cast<Hash>().ToArray();
+            var result = StandardFilters.Sort(_contextV20, list, "sortby").Cast<Hash>().ToArray();
             Assert.AreEqual(3, result.Count());
             Assert.AreEqual(hashWithNoSortByProperty["content"], result[0]["content"]);
             Assert.AreEqual(hash1["content"], result[1]["content"]);
             Assert.AreEqual(hash2["content"], result[2]["content"]);
         }
 
-        private static Hash CreateHash(string sortby, string content) =>
+        private static Hash CreateHash(int sortby, string content) =>
             new Hash
             {
                 { "sortby", sortby },
@@ -1299,6 +1364,21 @@ namespace DotLiquid.Tests
             Helper.AssertTemplateResult(
                 expected: "My great title",
                 template: "{{ 'my great title' | capitalize }}",
+                syntax: context.SyntaxCompatibilityLevel);
+        }
+
+        [Test]
+        public void TestCapitalizeV22()
+        {
+            var context = _contextV22;
+            Assert.AreEqual(null, StandardFilters.Capitalize(context: context, input: null));
+            Assert.AreEqual("", StandardFilters.Capitalize(context: context, input: ""));
+            Assert.AreEqual(" ", StandardFilters.Capitalize(context: context, input: " "));
+            Assert.AreEqual("My boss is mr. doe.", StandardFilters.Capitalize(context: context, input: "my boss is Mr. Doe."));
+
+            Helper.AssertTemplateResult(
+                expected: "My great title",
+                template: "{{ 'my Great Title' | capitalize }}",
                 syntax: context.SyntaxCompatibilityLevel);
         }
 

--- a/src/DotLiquid.Tests/Tags/CommentTests.cs
+++ b/src/DotLiquid.Tests/Tags/CommentTests.cs
@@ -1,0 +1,43 @@
+using DotLiquid.Tags;
+using NUnit.Framework;
+
+namespace DotLiquid.Tests.Tags
+{
+    [TestFixture]
+    public class CommentTests
+    {
+        [Test]
+        public void TestEmptyComment()
+        {
+            Assert.AreEqual(string.Empty, Template.Parse("{% comment %}{% endcomment %}").Render());
+
+            // Next test is specific to legacy parser and was removed from Ruby Liquid. Test that it is ignored is in TestShortHandSyntaxIsIgnored
+            Assert.AreEqual(string.Empty, Template.Parse("{##}", SyntaxCompatibility.DotLiquid20).Render());
+        }
+
+        [Test]
+        public void TestSimpleCommentValue()
+        {
+            Assert.AreEqual("", Template.Parse("{% comment %}howdy{% endcomment %}").Render());
+        }
+
+        [Test]
+        public void TestCommentsIgnoreLiquidMarkup()
+        {
+            Assert.AreEqual(
+                expected: "",
+                actual: Template.Parse("{% comment %}{% if 'gnomeslab' contains 'liquid' %}yes{% else %}no{ % endif %}{% endcomment %}").Render());
+        }
+
+        [Test]
+        public void TestCommentShorthand()
+        {
+            Assert.AreEqual("{% comment %}gnomeslab{% endcomment %}", Comment.FromShortHand("{# gnomeslab #}"));
+            Assert.AreEqual(null, Comment.FromShortHand(null));
+
+            Assert.AreEqual(
+                expected: "",
+                actual: Template.Parse("{#{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}#}", SyntaxCompatibility.DotLiquid20).Render());
+        }
+    }
+}

--- a/src/DotLiquid.Tests/Tags/LiteralTests.cs
+++ b/src/DotLiquid.Tests/Tags/LiteralTests.cs
@@ -12,44 +12,45 @@ namespace DotLiquid.Tests.Tags
         [Test]
         public void TestEmptyLiteral()
         {
-            Template t = Template.Parse("{% literal %}{% endliteral %}");
-            Assert.AreEqual(string.Empty, t.Render());
-            t = Template.Parse("{{{}}}");
-            Assert.AreEqual(string.Empty, t.Render());
+            Assert.AreEqual(string.Empty, Template.Parse("{% literal %}{% endliteral %}").Render());
+
+            // Next test is specific to legacy parser and was removed from Ruby Liquid. Test that it is ignored is in TestShortHandSyntaxIsIgnored
+            Assert.AreEqual(string.Empty, Template.Parse("{{{}}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]
         public void TestSimpleLiteralValue()
         {
-            Template t = Template.Parse("{% literal %}howdy{% endliteral %}");
-            Assert.AreEqual("howdy", t.Render());
+            Assert.AreEqual("howdy", Template.Parse("{% literal %}howdy{% endliteral %}").Render());
         }
 
         [Test]
         public void TestLiteralsIgnoreLiquidMarkup()
         {
-            Template t = Template.Parse("{% literal %}{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}{% endliteral %}");
-            Assert.AreEqual("{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}", t.Render());
+            Assert.AreEqual(
+                expected: "{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}",
+                actual: Template.Parse("{% literal %}{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}{% endliteral %}").Render());
         }
 
         [Test]
         public void TestShorthandSyntax()
         {
-            Template t = Template.Parse("{{{{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}}}}");
-            Assert.AreEqual("{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}", t.Render());
+            Assert.AreEqual(
+                expected: "{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}",
+                actual: Template.Parse("{{{{% if 'gnomeslab' contains 'liquid' %}yes{ % endif %}}}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]
         public void TestLiteralsDontRemoveComments()
         {
-            Template t = Template.Parse("{{{ {# comment #} }}}");
-            Assert.AreEqual("{# comment #}", t.Render());
+            Assert.AreEqual("{# comment #}", Template.Parse("{{{ {# comment #} }}}", SyntaxCompatibility.DotLiquid20).Render());
         }
 
         [Test]
         public void TestFromShorthand()
         {
             Assert.AreEqual("{% literal %}gnomeslab{% endliteral %}", Literal.FromShortHand("{{{gnomeslab}}}"));
+            Assert.AreEqual(null, Literal.FromShortHand(null));
         }
 
         [Test]

--- a/src/DotLiquid.Tests/TemplateTests.cs
+++ b/src/DotLiquid.Tests/TemplateTests.cs
@@ -8,38 +8,46 @@ namespace DotLiquid.Tests
     [TestFixture]
     public class TemplateTests
     {
+        private System.Collections.Generic.List<string> TokenizeValidateBackwardCompatibility(string input)
+        {
+            var v20 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid20);
+            var v22 = Tokenizer.Tokenize(input, SyntaxCompatibility.DotLiquid22);
+            CollectionAssert.AreEqual(v20, v22);
+            return v22;
+        }
+
         [Test]
         public void TestTokenizeStrings()
         {
-            CollectionAssert.AreEqual(new[] { " " }, Template.Tokenize(" "));
-            CollectionAssert.AreEqual(new[] { "hello world" }, Template.Tokenize("hello world"));
+            CollectionAssert.AreEqual(new[] { " " }, TokenizeValidateBackwardCompatibility(" "));
+            CollectionAssert.AreEqual(new[] { "hello world" }, TokenizeValidateBackwardCompatibility("hello world"));
         }
 
         [Test]
         public void TestTokenizeVariables()
         {
-            CollectionAssert.AreEqual(new[] { "{{funk}}" }, Template.Tokenize("{{funk}}"));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, Template.Tokenize(" {{funk}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, Template.Tokenize(" {{funk}} {{so}} {{brother}} "));
-            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, Template.Tokenize(" {{  funk  }} "));
+            CollectionAssert.AreEqual(new[] { "{{funk}}" }, TokenizeValidateBackwardCompatibility("{{funk}}"));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " " }, TokenizeValidateBackwardCompatibility(" {{funk}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " " }, TokenizeValidateBackwardCompatibility(" {{funk}} {{so}} {{brother}} "));
+            CollectionAssert.AreEqual(new[] { " ", "{{  funk  }}", " " }, TokenizeValidateBackwardCompatibility(" {{  funk  }} "));
         }
 
         [Test]
         public void TestTokenizeBlocks()
         {
-            CollectionAssert.AreEqual(new[] { "{%assign%}" }, Template.Tokenize("{%assign%}"));
-            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, Template.Tokenize(" {%assign%} "));
+            CollectionAssert.AreEqual(new[] { "{%assign%}" }, TokenizeValidateBackwardCompatibility("{%assign%}"));
+            CollectionAssert.AreEqual(new[] { " ", "{%assign%}", " " }, TokenizeValidateBackwardCompatibility(" {%assign%} "));
 
-            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, Template.Tokenize(" {%comment%} {%endcomment%} "));
-            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, Template.Tokenize("  {% comment %} {% endcomment %} "));
+            CollectionAssert.AreEqual(new[] { " ", "{%comment%}", " ", "{%endcomment%}", " " }, TokenizeValidateBackwardCompatibility(" {%comment%} {%endcomment%} "));
+            CollectionAssert.AreEqual(new[] { "  ", "{% comment %}", " ", "{% endcomment %}", " " }, TokenizeValidateBackwardCompatibility("  {% comment %} {% endcomment %} "));
         }
 
         [Test]
         public void TestInstanceAssignsPersistOnSameTemplateObjectBetweenParses()
         {
             Template t = new Template();
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
@@ -47,8 +55,8 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             t.MakeThreadSafe();
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
-            Assert.AreEqual("", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
@@ -72,16 +80,16 @@ namespace DotLiquid.Tests
         public void TestCustomAssignsDoNotPersistOnSameTemplate()
         {
             Template t = new Template();
-            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}").Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
-            Assert.AreEqual("", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
+            Assert.AreEqual("", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
         public void TestCustomAssignsSquashInstanceAssigns()
         {
             Template t = new Template();
-            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
-            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}").Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
+            Assert.AreEqual("from instance assigns", t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("from custom assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { foo = "from custom assigns" })));
         }
 
         [Test]
@@ -89,9 +97,9 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             Assert.AreEqual("from instance assigns",
-                t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}").Render());
+                t.ParseInternal("{% assign foo = 'from instance assigns' %}{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
             t.Assigns["foo"] = "from persistent assigns";
-            Assert.AreEqual("from persistent assigns", t.ParseInternal("{{ foo }}").Render());
+            Assert.AreEqual("from persistent assigns", t.ParseInternal("{{ foo }}", SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
@@ -99,9 +107,9 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             int global = 0;
-            t.Assigns["number"] = (Proc) (c => ++global);
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render());
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render());
+            t.Assigns["number"] = (Proc)(c => ++global);
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render());
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render());
             Assert.AreEqual("1", t.Render());
         }
 
@@ -110,41 +118,44 @@ namespace DotLiquid.Tests
         {
             Template t = new Template();
             int global = 0;
-            Hash assigns = Hash.FromAnonymousObject(new { number = (Proc) (c => ++global) });
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render(assigns));
-            Assert.AreEqual("1", t.ParseInternal("{{number}}").Render(assigns));
+            Hash assigns = Hash.FromAnonymousObject(new { number = (Proc)(c => ++global) });
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render(assigns));
+            Assert.AreEqual("1", t.ParseInternal("{{number}}", SyntaxCompatibility.DotLiquid22).Render(assigns));
             Assert.AreEqual("1", t.Render(assigns));
         }
 
         [Test]
         public void TestErbLikeTrimmingLeadingWhitespace()
         {
-            Template t = Template.Parse("foo\n\t  {%- if true %}hi tobi{% endif %}");
-            Assert.AreEqual("foo\nhi tobi", t.Render());
+            string template = "foo\n\t  {%- if true %}hi tobi{% endif %}";
+            Assert.AreEqual("foo\nhi tobi", Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render());
+            Assert.AreEqual("foohi tobi", Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
         public void TestErbLikeTrimmingTrailingWhitespace()
         {
-            Template t = Template.Parse("{% if true -%}\nhi tobi\n{% endif %}");
-            Assert.AreEqual("hi tobi\n", t.Render());
+            string template = "{% if true -%}\n hi tobi\n{% endif %}";
+            Assert.AreEqual(" hi tobi\n", Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render());
+            Assert.AreEqual("hi tobi\n", Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render());
         }
 
         [Test]
         public void TestErbLikeTrimmingLeadingAndTrailingWhitespace()
         {
-            Template t = Template.Parse(@"<ul>
+            string template = @"<ul>
 {% for item in tasks -%}
     {%- if true -%}
     <li>{{ item }}</li>
     {%- endif -%}
 {% endfor -%}
-</ul>");
-            Assert.AreEqual(@"<ul>
-    <li>foo</li>
-    <li>bar</li>
-    <li>baz</li>
-</ul>", t.Render(Hash.FromAnonymousObject(new { tasks = new [] { "foo", "bar", "baz" } })));
+</ul>";
+            Assert.AreEqual(
+                "<ul>\r\n    <li>foo</li>\r\n    <li>bar</li>\r\n    <li>baz</li>\r\n</ul>",
+                Template.Parse(template, SyntaxCompatibility.DotLiquid20).Render(Hash.FromAnonymousObject(new { tasks = new[] { "foo", "bar", "baz" } })));
+            Assert.AreEqual(
+                "<ul>\r\n<li>foo</li><li>bar</li><li>baz</li></ul>",
+                Template.Parse(template, SyntaxCompatibility.DotLiquid22).Render(Hash.FromAnonymousObject(new { tasks = new[] { "foo", "bar", "baz" } })));
         }
 
         [Test]
@@ -292,7 +303,7 @@ namespace DotLiquid.Tests
         [Test]
         public void TestHtmlEncodingFilter()
         {
-            Template.RegisterValueTypeTransformer(typeof(string), m => WebUtility.HtmlEncode((string) m));
+            Template.RegisterValueTypeTransformer(typeof(string), m => WebUtility.HtmlEncode((string)m));
 
             Template template = Template.Parse("{{var1}} {{var2}}");
 
@@ -315,7 +326,7 @@ namespace DotLiquid.Tests
         public void TestRegisterSimpleTypeTransformIntoAnonymousType()
         {
             // specify a transform function
-            Template.RegisterSafeType(typeof(MySimpleType2), x => new { Name = ((MySimpleType2)x).Name } );
+            Template.RegisterSafeType(typeof(MySimpleType2), x => new { Name = ((MySimpleType2)x).Name });
             Template template = Template.Parse("{{context.Name}}");
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
@@ -327,7 +338,7 @@ namespace DotLiquid.Tests
         public void TestRegisterInterfaceTransformIntoAnonymousType()
         {
             // specify a transform function
-            Template.RegisterSafeType(typeof(IMySimpleInterface2), x => new { Name = ((IMySimpleInterface2) x).Name });
+            Template.RegisterSafeType(typeof(IMySimpleInterface2), x => new { Name = ((IMySimpleInterface2)x).Name });
             Template template = Template.Parse("{{context.Name}}");
 
             var output = template.Render(Hash.FromAnonymousObject(new { context = new MySimpleType2 { Name = "worked" } }));
@@ -410,7 +421,7 @@ namespace DotLiquid.Tests
 
                 // RenderParameters Applies Template Defaults 
                 Template.DefaultSyntaxCompatibilityLevel = SyntaxCompatibility.DotLiquid21;
-                var renderParamsDefault = new RenderParameters(CultureInfo.CurrentCulture); 
+                var renderParamsDefault = new RenderParameters(CultureInfo.CurrentCulture);
                 Assert.AreEqual(Template.DefaultSyntaxCompatibilityLevel, renderParamsDefault.SyntaxCompatibilityLevel);
 
                 // Context Applies Template Defaults

--- a/src/DotLiquid/Context.cs
+++ b/src/DotLiquid/Context.cs
@@ -18,12 +18,12 @@ namespace DotLiquid
     /// </summary>
     public class Context
     {
+        private static readonly HashSet<char> SpecialCharsSet = new HashSet<char>() { '\'', '"', '(', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '-' };
         private static readonly Regex SingleQuotedRegex = R.C(R.Q(@"^'(.*)'$"));
         private static readonly Regex DoubleQuotedRegex = R.C(R.Q(@"^""(.*)""$"));
         private static readonly Regex IntegerRegex = R.C(R.Q(@"^([+-]?\d+)$"));
         private static readonly Regex RangeRegex = R.C(R.Q(@"^\((\S+)\.\.(\S+)\)$"));
         private static readonly Regex NumericRegex = R.C(R.Q(@"^([+-]?\d[\d\.|\,]+)$"));
-        private static readonly Regex SquareBracketedRegex = R.C(R.Q(@"^\[(.*)\]$"));
         private static readonly Regex VariableParserRegex = R.C(Liquid.VariableParser);
 
         private readonly ErrorsOutputMode _errorsOutputMode;
@@ -230,6 +230,9 @@ namespace DotLiquid
                 return Strainer.Invoke(method, args);
             }
 
+            if (SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22)
+                throw new FilterNotFoundException(method); // this will be caught and rethrown in caller with correct message
+
             return args.First();
         }
 
@@ -359,59 +362,70 @@ namespace DotLiquid
                     return false;
                 case "blank":
                 case "empty":
-                    return new Symbol(o => o is IEnumerable && !((IEnumerable)o).Cast<object>().Any());
+                    return new Symbol(o => (o is IEnumerable enumerableO) && !enumerableO.Cast<object>().Any());
             }
 
-            // Single quoted strings.
-            Match match = SingleQuotedRegex.Match(key);
-            if (match.Success)
-                return match.Groups[1].Value;
-
-            // Double quoted strings.
-            match = DoubleQuotedRegex.Match(key);
-            if (match.Success)
-                return match.Groups[1].Value;
-
-            // Integer.
-            match = IntegerRegex.Match(key);
-            if (match.Success)
+            var firstChar = key[0];
+            if (SpecialCharsSet.Contains(firstChar))
             {
-                try
+                switch (firstChar)
                 {
-                    return Convert.ToInt32(match.Groups[1].Value);
-                }
-                catch (OverflowException)
-                {
-                    return Convert.ToInt64(match.Groups[1].Value);
+                    case '\'':
+                        // Single quoted strings.
+                        Match match = SingleQuotedRegex.Match(key);
+                        if (match.Success)
+                            return match.Groups[1].Value;
+                        break;
+                    case '"':
+                        // Double quoted strings.
+                        match = DoubleQuotedRegex.Match(key);
+                        if (match.Success)
+                            return match.Groups[1].Value;
+                        break;
+                    case '(':
+                        // Ranges.
+                        match = RangeRegex.Match(key);
+                        if (match.Success)
+                            return Range.Inclusive(Convert.ToInt32(Resolve(match.Groups[1].Value)),
+                                Convert.ToInt32(Resolve(match.Groups[2].Value)));
+                        break;
+                    default:
+                        // Integer.
+                        match = IntegerRegex.Match(key);
+                        if (match.Success)
+                        {
+                            try
+                            {
+                                return Convert.ToInt32(match.Groups[1].Value);
+                            }
+                            catch (OverflowException)
+                            {
+                                return Convert.ToInt64(match.Groups[1].Value);
+                            }
+                        }
+
+                        // Floating point numbers.
+                        match = NumericRegex.Match(key);
+                        if (match.Success)
+                        {
+                            // For cultures with "," as the decimal separator, allow
+                            // both "," and "." to be used as the separator.
+                            // First try to parse using current culture.
+                            // If that fails, try to parse using invariant culture.
+                            // Also, first try higher precision decimal.
+                            // If that fails, try to parse as double (precision float).
+                            // Double is less precise but has a larger range.
+                            if (decimal.TryParse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, FormatProvider, out decimal parsedDecimalCurrentCulture))
+                                return parsedDecimalCurrentCulture;
+                            if (decimal.TryParse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out decimal parsedDecimalInvariantCulture))
+                                return parsedDecimalInvariantCulture;
+                            if (double.TryParse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, FormatProvider, out double parsedDouble))
+                                return parsedDouble;
+                            return double.Parse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture);
+                        }
+                        break;
                 }
             }
-
-            // Ranges.
-            match = RangeRegex.Match(key);
-            if (match.Success)
-                return Range.Inclusive(Convert.ToInt32(Resolve(match.Groups[1].Value)),
-                    Convert.ToInt32(Resolve(match.Groups[2].Value)));
-
-            // Floating point numbers.
-            match = NumericRegex.Match(key);
-            if (match.Success)
-            {
-                // For cultures with "," as the decimal separator, allow
-                // both "," and "." to be used as the separator.
-                // First try to parse using current culture.
-                // If that fails, try to parse using invariant culture.
-                // Also, first try higher precision decimal.
-                // If that fails, try to parse as double (precision float).
-                // Double is less precise but has a larger range.
-                if (decimal.TryParse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, FormatProvider, out decimal parsedDecimalCurrentCulture))
-                    return parsedDecimalCurrentCulture;
-                if (decimal.TryParse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture, out decimal parsedDecimalInvariantCulture))
-                    return parsedDecimalInvariantCulture;
-                if (double.TryParse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, FormatProvider, out double parsedDouble))
-                    return parsedDouble;
-                return double.Parse(match.Groups[1].Value, NumberStyles.Number | NumberStyles.Float, CultureInfo.InvariantCulture);
-            }
-
             return Variable(key, notifyNotFound);
         }
 
@@ -422,29 +436,42 @@ namespace DotLiquid
         /// the hierarchy
         /// </summary>
         /// <param name="key"></param>
+        /// <param name="variable"></param>
         /// <returns></returns>
-        private object FindVariable(string key)
+        private bool TryFindVariable(string key, out object variable)
         {
+            bool foundVariable = false;
+            object foundValue = null;
             Hash scope = Scopes.FirstOrDefault(s => s.ContainsKey(key));
-            object variable = null;
             if (scope == null)
             {
-                foreach (Hash e in Environments)
-                    if ((variable = LookupAndEvaluate(e, key)) != null)
+                foreach (Hash environment in Environments)
+                {
+                    foundVariable = TryEvaluateHashOrArrayLikeObject(environment, key, out foundValue);
+                    if (foundVariable)
                     {
-                        scope = e;
+                        scope = environment;
                         break;
                     }
-            }
-            scope = scope ?? Environments.LastOrDefault() ?? Scopes.Last();
-            variable = variable ?? LookupAndEvaluate(scope, key);
+                }
 
-            variable = Liquidize(variable);
+                if (scope == null)
+                {
+                    scope = Environments.LastOrDefault() ?? Scopes.Last();
+                    foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out foundValue);
+                }
+            }
+            else
+            {
+                foundVariable = TryEvaluateHashOrArrayLikeObject(scope, key, out foundValue);
+            }
+
+            variable = Liquidize(foundValue);
             if (variable is IContextAware contextAwareVariable)
             {
                 contextAwareVariable.Context = this;
             }
-            return variable;
+            return foundVariable;
         }
 
         /// <summary>
@@ -461,33 +488,39 @@ namespace DotLiquid
         /// <returns></returns>
         private object Variable(string markup, bool notifyNotFound)
         {
-            List<string> parts = R.Scan(markup, VariableParserRegex);
-
-            // first item in list, if any
-            string firstPart = parts.TryGetAtIndex(0);
-
-            Match firstPartSquareBracketedMatch = SquareBracketedRegex.Match(firstPart);
-            if (firstPartSquareBracketedMatch.Success)
-                firstPart = Resolve(firstPartSquareBracketedMatch.Groups[1].Value).ToString();
-
-            object @object;
-            if ((@object = FindVariable(firstPart)) == null)
+            using (var partsEnumerator = SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22 ? Tokenizer.GetVariableEnumerator(markup) : R.Scan(markup, VariableParserRegex).GetEnumerator())
             {
+                if (TryGetVariable(partsEnumerator, out var variable))
+                    return variable;
                 if (notifyNotFound)
                     Errors.Add(new VariableNotFoundException(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), markup)));
                 return null;
             }
+        }
+
+        private bool TryGetVariable(IEnumerator<string> partsEnumerator, out object variable)
+        {
+            // first item in list, if any
+            string firstPart = partsEnumerator.MoveNext() ? partsEnumerator.Current : null;
+            if (firstPart != null && firstPart[0] == '[')
+                firstPart = Resolve(firstPart.Substring(1, firstPart.Length - 2)).ToString();
+
+            object @object;
+            if (firstPart == null || !TryFindVariable(firstPart, out @object))
+            {
+                variable = null;
+                return false;
+            }
 
             // try to resolve the rest of the parts (starting from the second item in the list)
-            for (int i = 1; i < parts.Count; ++i)
+            while (partsEnumerator.MoveNext())
             {
-                var forEachPart = parts[i];
-                Match partSquareBracketedMatch = SquareBracketedRegex.Match(forEachPart);
-                bool partResolved = partSquareBracketedMatch.Success;
+                string forEachPart = partsEnumerator.Current;
+                bool partResolved = forEachPart[0] == '[';
 
                 object part = forEachPart;
                 if (partResolved)
-                    part = Resolve(partSquareBracketedMatch.Groups[1].Value);
+                    part = Resolve(forEachPart.Substring(1, forEachPart.Length - 2));
 
                 // If object is a KeyValuePair, we treat it a bit differently - we might be rendering
                 // an included template.
@@ -517,11 +550,10 @@ namespace DotLiquid
                     }
                     // If object is a hash- or array-like object we look for the
                     // presence of the key and if its available we return it
-                    else if (IsHashOrArrayLikeObject(@object, part))
+                    else if (TryEvaluateHashOrArrayLikeObject(@object, part, out var hashObj))
                     {
                         // If its a proc we will replace the entry with the proc
-                        object res = LookupAndEvaluate(@object, part);
-                        @object = Liquidize(res);
+                        @object = Liquidize(hashObj);
                     }
                     // Some special cases. If the part wasn't in square brackets and
                     // no key with the same name was found we interpret following calls
@@ -546,8 +578,8 @@ namespace DotLiquid
                     // keywords either. The only thing we got left is to return nil
                     else
                     {
-                        Errors.Add(new VariableNotFoundException(string.Format(Liquid.ResourceManager.GetString("VariableNotFoundException"), markup)));
-                        return null;
+                        variable = null;
+                        return false;
                     }
                 }
 
@@ -557,62 +589,35 @@ namespace DotLiquid
                     contextAwareObject.Context = this;
                 }
             }
-
-            return @object;
+            variable = @object;
+            return true;
         }
 
-        private static bool IsHashOrArrayLikeObject(object obj, object part)
+        private bool TryEvaluateHashOrArrayLikeObject(object obj, object key, out object value)
         {
+            value = null;
+
             if (obj == null)
                 return false;
 
-            if ((obj is IDictionary && ((IDictionary)obj).Contains(part)))
-                return true;
+            if ((obj is IDictionary dictionaryObj && dictionaryObj.Contains(key)))
+                value = dictionaryObj[key];
 
             // Resolve #350/#417, add support for rendering of a nested  ExpandoObject
-            if (obj is IDictionary<string, object> dictionaryObject && dictionaryObject.ContainsKey(part.ToString()))
-                return true;
-
-            if ((obj is IList) && (part is int || part is long))
-                return true;
-
-            if (TypeUtility.IsAnonymousType(obj.GetType()) && obj.GetType().GetRuntimeProperty((string)part) != null)
-                return true;
-
-            if ((obj is IIndexable) && ((IIndexable)obj).ContainsKey(part))
-                return true;
-
-            return false;
-        }
-
-        private object LookupAndEvaluate(object obj, object key)
-        {
-            object value;
-            if (obj is IDictionary dictionaryObj)
-            {
-                value = dictionaryObj[key];
-            }
-            // Resolve #350/#417, add support for rendering of a nested ExpandoObject
-            else if (obj is IDictionary<string, object> dictionaryObject)
-            {
+            else if (obj is IDictionary<string, object> dictionaryObject && dictionaryObject.ContainsKey(key.ToString()))
                 value = dictionaryObject[key.ToString()];
-            }
-            else if (obj is IList listObj)
-            {
+
+            else if ((obj is IList listObj) && (key is int || key is long))
                 value = listObj[Convert.ToInt32(key)];
-            }
-            else if (TypeUtility.IsAnonymousType(obj.GetType()))
-            {
+
+            else if (TypeUtility.IsAnonymousType(obj.GetType()) && obj.GetType().GetRuntimeProperty((string)key) != null)
                 value = obj.GetType().GetRuntimeProperty((string)key).GetValue(obj, null);
-            }
-            else if (obj is IIndexable indexableObj)
-            {
+
+            else if ((obj is IIndexable indexableObj) && indexableObj.ContainsKey(key))
                 value = indexableObj[key];
-            }
+
             else
-            {
-                throw new NotSupportedException();
-            }
+                return false;
 
             if (value is Proc procValue)
             {
@@ -633,10 +638,10 @@ namespace DotLiquid
                 {
                     throw new NotSupportedException();
                 }
-                return newValue;
+                value = newValue;
             }
 
-            return value;
+            return true;
         }
 
         private static object Liquidize(object obj)
@@ -732,7 +737,7 @@ namespace DotLiquid
                 foreach (Hash env in Environments)
                     if (env.ContainsKey(k))
                     {
-                        tempAssigns[k] = LookupAndEvaluate(env, k);
+                        tempAssigns[k] = env[k];
                         break;
                     }
 

--- a/src/DotLiquid/ExtendedFilters.cs
+++ b/src/DotLiquid/ExtendedFilters.cs
@@ -1,0 +1,43 @@
+using System.Text.RegularExpressions;
+using System.Globalization;
+
+namespace DotLiquid
+{
+    /// <summary>
+    /// Extended DotLiquid Filters. Not registered by default.
+    /// </summary>
+    public static class ExtendedFilters
+    {
+        /// <summary>
+        /// Capitalize all the words in the input sentence
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string Titleize(Context context, string input)
+        {
+            return input.IsNullOrWhiteSpace()
+                ? input
+#if CORE
+                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
+#else
+                : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+#endif
+        }
+
+        /// <summary>
+        /// Converts just the first character to uppercase
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string UpcaseFirst(Context context, string input)
+        {
+            if (input.IsNullOrWhiteSpace())
+                return input;
+
+            var trimmed = input.TrimStart();
+            return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1);
+        }
+    }
+}

--- a/src/DotLiquid/Hash.cs
+++ b/src/DotLiquid/Hash.cs
@@ -7,6 +7,9 @@ using System.Reflection;
 
 namespace DotLiquid
 {
+    /// <summary>
+    /// Represents a collection of keys and values and is a DotLiquid safe type
+    /// </summary>
     public class Hash : IDictionary<string, object>, IDictionary
     {
         #region Static fields
@@ -25,11 +28,10 @@ namespace DotLiquid
         #region Static construction methods
 
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class and populates it with the contents of an anonymous object
         /// </summary>
-        /// <param name="anonymousObject"></param>
+        /// <param name="anonymousObject">The anonymous object</param>
         /// <param name="includeBaseClassProperties">If this is set to true, method will map base class' properties too. </param>
-        /// <returns></returns>
         public static Hash FromAnonymousObject(object anonymousObject, bool includeBaseClassProperties = false)
         {
             Hash result = new Hash();
@@ -50,29 +52,7 @@ namespace DotLiquid
         {
             var cacheKey = type.FullName + "_" + (includeBaseClassProperties ? "WithBaseProperties" : "WithoutBaseProperties");
 
-            if (!mapperCache.TryGetValue(cacheKey, out Action<object, Hash> mapper))
-            {
-                /* Bogdan Mart: Note regarding concurrency:
-                 * This is concurrent dictionary, but if this will be called from two threads
-                 * this code would generate two same mappers, which will cause some CPU overhead.
-                 * But I have no idea on what I can lock here, first thought was to use lock(type),
-                 * but that could cause deadlock, if some outside code will lock Type.
-                 * Only correct solution would be to use ConcurrentDictionary<Type, Action<object, Hash>>
-                 * with some CAS race, and then locking, or Semaphore, but first will add complexity, 
-                 * second would add overhead in locking on Kernel-level named object.
-                 * 
-                 * So I assume tradeoff in not using locks here is better, 
-                 * we at most will waste some CPU cycles on code generation, 
-                 * but RAM would be collected, due to http://stackoverflow.com/questions/5340201/
-                 * 
-                 * If someone have conserns, than one can lock(mapperCache) but that would 
-                 * create bottleneck, as only one mapper could be generated at a time.
-                 */
-                mapper = GenerateMapper(type, includeBaseClassProperties);
-                mapperCache[cacheKey] = mapper;
-            }
-
-            return mapper;
+            return mapperCache.GetOrAdd(cacheKey, (key) => GenerateMapper(type, includeBaseClassProperties));
         }
 
         private static void AddBaseClassProperties(Type type, List<PropertyInfo> propertyList)
@@ -124,6 +104,10 @@ namespace DotLiquid
             return expr.Compile();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class and populates it with the contents of a dictionary
+        /// </summary>
+        /// <param name="dictionary">The Dictionary object</param>
         public static Hash FromDictionary(IDictionary<string, object> dictionary)
         {
             var hash = new Hash();
@@ -135,18 +119,29 @@ namespace DotLiquid
 
         #region Constructors
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class that is empty and sets the default value
+        /// </summary>
+        /// <param name="defaultValue">The default value to return if the key lookup fails</param>
         public Hash(object defaultValue)
             : this()
         {
             _defaultValue = defaultValue;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class that is empty and sets a method to return a default value
+        /// </summary>
+        /// <param name="lambda">The method to execute if the key lookup fails</param>
         public Hash(Func<Hash, string, object> lambda)
             : this()
         {
             _lambda = lambda;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotLiquid.Hash">Hash</see> class that is empty
+        /// </summary>
         public Hash()
         {
             _nestedDictionary = new Dictionary<string, object>(Template.NamingConvention.StringComparer);
@@ -154,12 +149,21 @@ namespace DotLiquid
 
         #endregion
 
+        /// <summary>
+        /// Merges a dictionary object into the current <see cref="DotLiquid.Hash">Hash</see>.
+        /// </summary>
+        /// <param name="otherValues">The dictionary object to be merged into the Hash.</param>
         public void Merge(IDictionary<string, object> otherValues)
         {
             foreach (string key in otherValues.Keys)
                 _nestedDictionary[key] = otherValues[key];
         }
 
+        /// <summary>
+        /// Gets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value associated with the specified key. If key does not exist, returns the default value, default lambda expression return value, or null.</returns>
         protected virtual object GetValue(string key)
         {
             if (_nestedDictionary.ContainsKey(key))
@@ -174,6 +178,12 @@ namespace DotLiquid
             return null;
         }
 
+        /// <summary>
+        /// Provides strongly-typed access to each of the keys in the Hash
+        /// </summary>
+        /// <typeparam name="T">A generic parameter that specifies the return type of the column.</typeparam>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value, of type T, associated with the specified key.</returns>
         public T Get<T>(string key)
         {
             return (T)this[key];
@@ -181,11 +191,13 @@ namespace DotLiquid
 
         #region IDictionary<string, object>
 
+        /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
             return _nestedDictionary.GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public void Remove(object key)
         {
             ((IDictionary)_nestedDictionary).Remove(key);
@@ -207,21 +219,29 @@ namespace DotLiquid
             return _nestedDictionary.GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public void Add(KeyValuePair<string, object> item)
         {
             ((IDictionary<string, object>)_nestedDictionary).Add(item);
         }
 
+        /// <summary>
+        /// Determines whether the <see cref="DotLiquid.Hash">Hash</see> contains the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="DotLiquid.Hash">Hash</see></param>
+        /// <returns>true if the <see cref="DotLiquid.Hash">Hash</see> contains an element with the specified key or a default value; otherwise, false.</returns>
         public virtual bool Contains(object key)
         {
-            return ((IDictionary)_nestedDictionary).Contains(key);
+            return _lambda != null || _defaultValue != null || ((IDictionary)_nestedDictionary).Contains(key);
         }
 
+        /// <inheritdoc/>
         public void Add(object key, object value)
         {
             ((IDictionary)_nestedDictionary).Add(key, value);
         }
 
+        /// <inheritdoc/>
         public void Clear()
         {
             _nestedDictionary.Clear();
@@ -232,16 +252,19 @@ namespace DotLiquid
             return ((IDictionary)_nestedDictionary).GetEnumerator();
         }
 
+        /// <inheritdoc/>
         public bool Contains(KeyValuePair<string, object> item)
         {
             return ((IDictionary<string, object>)_nestedDictionary).Contains(item);
         }
 
+        /// <inheritdoc/>
         public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
             ((IDictionary<string, object>)_nestedDictionary).CopyTo(array, arrayIndex);
         }
 
+        /// <inheritdoc/>
         public bool Remove(KeyValuePair<string, object> item)
         {
             return ((IDictionary<string, object>)_nestedDictionary).Remove(item);
@@ -251,21 +274,25 @@ namespace DotLiquid
 
         #region IDictionary
 
+        /// <inheritdoc/>
         public void CopyTo(Array array, int index)
         {
             ((IDictionary)_nestedDictionary).CopyTo(array, index);
         }
 
+        /// <inheritdoc/>
         public int Count
         {
             get { return _nestedDictionary.Count; }
         }
 
+        /// <inheritdoc/>
         public object SyncRoot
         {
             get { return ((IDictionary)_nestedDictionary).SyncRoot; }
         }
 
+        /// <inheritdoc/>
         public bool IsSynchronized
         {
             get { return ((IDictionary)_nestedDictionary).IsSynchronized; }
@@ -276,42 +303,54 @@ namespace DotLiquid
             get { return ((IDictionary)_nestedDictionary).Values; }
         }
 
+        /// <inheritdoc />
         public bool IsReadOnly
         {
             get { return ((IDictionary<string, object>)_nestedDictionary).IsReadOnly; }
         }
 
+        /// <inheritdoc />
         public bool IsFixedSize
         {
             get { return ((IDictionary)_nestedDictionary).IsFixedSize; }
         }
 
+        /// <summary>
+        /// Determines whether the <see cref="DotLiquid.Hash">Hash</see> contains the specified key.
+        /// </summary>
+        /// <param name="key">The key to locate in the <see cref="DotLiquid.Hash">Hash</see></param>
+        /// <returns>true if the <see cref="DotLiquid.Hash">Hash</see> contains an element with the specified key or a default value; otherwise, false.</returns>
         public bool ContainsKey(string key)
         {
-            return _nestedDictionary.ContainsKey(key);
+            return _lambda != null || _defaultValue != null || _nestedDictionary.ContainsKey(key);
         }
 
+        /// <inheritdoc/>
         public void Add(string key, object value)
         {
             _nestedDictionary.Add(key, value);
         }
 
+        /// <inheritdoc/>
         public bool Remove(string key)
         {
             return _nestedDictionary.Remove(key);
         }
 
+        /// <inheritdoc/>
         public bool TryGetValue(string key, out object value)
         {
             return _nestedDictionary.TryGetValue(key, out value);
         }
 
+        /// <inheritdoc/>
         public object this[string key]
         {
             get { return GetValue(key); }
             set { _nestedDictionary[key] = value; }
         }
 
+        /// <inheritdoc/>
         public ICollection<string> Keys
         {
             get { return _nestedDictionary.Keys; }
@@ -322,6 +361,7 @@ namespace DotLiquid
             get { return ((IDictionary)_nestedDictionary).Keys; }
         }
 
+        /// <inheritdoc/>
         public ICollection<object> Values
         {
             get { return _nestedDictionary.Values; }

--- a/src/DotLiquid/Liquid.cs
+++ b/src/DotLiquid/Liquid.cs
@@ -20,14 +20,11 @@ namespace DotLiquid
         public static readonly string VariableSegment = R.Q(@"[\w\-]");
         public static readonly string VariableStart = R.Q(@"\{\{");
         public static readonly string VariableEnd = R.Q(@"\}\}");
-        public static readonly string VariableIncompleteEnd = R.Q(@"\}\}?");
         public static readonly string QuotedString = R.Q(@"""[^""]*""|'[^']*'");
         public static readonly string QuotedFragment = string.Format(R.Q(@"{0}|(?:[^\s,\|'""]|{0})+"), QuotedString);
         public static readonly string QuotedAssignFragment = string.Format(R.Q(@"{0}|(?:[^\s\|'""]|{0})+"), QuotedString);
         public static readonly string TagAttributes = string.Format(R.Q(@"(\w+)\s*\:\s*({0})"), QuotedFragment);
         public static readonly string AnyStartingTag = R.Q(@"\{\{|\{\%");
-        public static readonly string PartialTemplateParser = string.Format(R.Q(@"{0}.*?{1}|{2}.*?{3}"), TagStart, TagEnd, VariableStart, VariableIncompleteEnd);
-        public static readonly string TemplateParser = string.Format(R.Q(@"({0}|{1})"), PartialTemplateParser, AnyStartingTag);
         public static readonly string VariableParser = string.Format(R.Q(@"\[[^\]]+\]|{0}+\??"), VariableSegment);
         public static readonly string LiteralShorthand = R.Q(@"^(?:\{\{\{\s?)(.*?)(?:\s*\}\}\})$");
         public static readonly string CommentShorthand = R.Q(@"^(?:\{\s?\#\s?)(.*?)(?:\s*\#\s?\})$");

--- a/src/DotLiquid/Properties/Resources.it.resx
+++ b/src/DotLiquid/Properties/Resources.it.resx
@@ -222,6 +222,9 @@
   <data name="VariableNotFoundException" xml:space="preserve">
     <value>Errore - La variabile '{0}' non è stata trovata</value>
   </data>
+  <data name="VariableNotTerminatedException" xml:space="preserve">
+    <value>La variable '{0}' non è stata terminata correttamente</value>
+  </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>la chiave non è stata trovata</value>
   </data>

--- a/src/DotLiquid/Properties/Resources.resx
+++ b/src/DotLiquid/Properties/Resources.resx
@@ -222,6 +222,9 @@
   <data name="VariableNotFoundException" xml:space="preserve">
     <value>Error - Variable '{0}' could not be found</value>
   </data>
+  <data name="VariableNotTerminatedException" xml:space="preserve">
+    <value>Variable '{0}' was not properly terminated</value>
+  </data>
   <data name="WeakTableKeyNotFoundException" xml:space="preserve">
     <value>key could not be found</value>
   </data>

--- a/src/DotLiquid/StandardFilters.cs
+++ b/src/DotLiquid/StandardFilters.cs
@@ -17,6 +17,34 @@ namespace DotLiquid
     /// <see href="https://shopify.github.io/liquid/filters/"/>
     public static class StandardFilters
     {
+
+#if NETSTANDARD1_3
+        private class StringAwareObjectComparer : IComparer
+        {
+            private readonly StringComparer _stringComparer;
+
+            public StringAwareObjectComparer(StringComparer stringComparer)
+            {
+                _stringComparer = stringComparer;
+            }
+
+            public int Compare(Object x, Object y)
+            {
+                if (x == y)
+                    return 0;
+                if (x == null)
+                    return -1;
+                if (y == null)
+                    return 1;
+
+                if (x is string textX && y is string textY)
+                    return _stringComparer.Compare(textX, textY);
+
+                return Comparer<object>.Default.Compare(x, y);
+            }
+        }
+#endif
+
         /// <summary>
         /// Return the size of an array or of an string
         /// </summary>
@@ -117,22 +145,18 @@ namespace DotLiquid
         /// <returns></returns>
         public static string Capitalize(Context context, string input)
         {
+            if (context.SyntaxCompatibilityLevel < SyntaxCompatibility.DotLiquid22)
+            {
+                if (context.SyntaxCompatibilityLevel == SyntaxCompatibility.DotLiquid21)
+                    return ExtendedFilters.UpcaseFirst(context, input);
+                return ExtendedFilters.Titleize(context, input);
+            }
+
             if (input.IsNullOrWhiteSpace())
                 return input;
 
-            if (context.SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid21)
-            {
-                var trimmed = input.TrimStart();
-                return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1);
-            }
-
-            return string.IsNullOrEmpty(input)
-                ? input
-#if CORE
-                : Regex.Replace(input, @"\b(\w)", m => m.Value.ToUpper(), RegexOptions.None, Template.RegexTimeOut);
-#else
-                : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
-#endif
+            var trimmed = input.TrimStart();
+            return input.Substring(0, input.Length - trimmed.Length) + char.ToUpper(trimmed[0]) + trimmed.Substring(1).ToLower();
         }
 
         /// <summary>
@@ -347,16 +371,36 @@ namespace DotLiquid
 
         /// <summary>
         /// Sort elements of the array
-        /// provide optional property with which to sort an array of hashes or drops
         /// </summary>
-        /// <param name="input"></param>
-        /// <param name="property"></param>
-        /// <returns></returns>
-        public static IEnumerable Sort(object input, string property = null)
+        /// <param name="context">The DotLiquid context</param>
+        /// <param name="input">The object to sort</param>
+        /// <param name="property">Optional property with which to sort an array of hashes or drops</param>
+        public static IEnumerable Sort(Context context, object input, string property = null)
         {
             if (input == null)
                 return null;
 
+            if (context.SyntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22)
+                return SortInternal(StringComparer.Ordinal, input, property);
+            else
+                return SortInternal(StringComparer.OrdinalIgnoreCase, input, property);
+        }
+
+        /// <summary>
+        /// Sort elements of the array in case-insensitive order
+        /// </summary>
+        /// <param name="input">The object to sort</param>
+        /// <param name="property">Optional property with which to sort an array of hashes or drops</param>
+        public static IEnumerable SortNatural(object input, string property = null)
+        {
+            if (input == null)
+                return null;
+
+            return SortInternal(StringComparer.OrdinalIgnoreCase, input, property);
+        }
+
+        private static IEnumerable SortInternal(StringComparer stringComparer, object input, string property = null)
+        {
             List<object> ary;
             if (input is IEnumerable<Hash> enumerableHash && !string.IsNullOrEmpty(property))
                 ary = enumerableHash.Cast<object>().ToList();
@@ -370,17 +414,23 @@ namespace DotLiquid
             if (!ary.Any())
                 return ary;
 
+#if NETSTANDARD1_3
+            var comparer = new StringAwareObjectComparer(stringComparer);
+#else
+            var comparer = stringComparer;
+#endif 
+
             if (string.IsNullOrEmpty(property))
             {
-                ary.Sort();
+                ary.Sort((a, b) => comparer.Compare(a, b));
             }
             else if ((ary.All(o => o is IDictionary)) && (ary.Any(o => ((IDictionary)o).Contains(property))))
             {
-                ary.Sort((a, b) => Comparer<object>.Default.Compare(((IDictionary)a)[property], ((IDictionary)b)[property]));
+                ary.Sort((a, b) => comparer.Compare(((IDictionary)a)[property], ((IDictionary)b)[property]));
             }
             else if (ary.All(o => o.RespondTo(property)))
             {
-                ary.Sort((a, b) => Comparer<object>.Default.Compare(a.Send(property), b.Send(property)));
+                ary.Sort((a, b) => comparer.Compare(a.Send(property), b.Send(property)));
             }
 
             return ary;

--- a/src/DotLiquid/SyntaxCompatibilityEnum.cs
+++ b/src/DotLiquid/SyntaxCompatibilityEnum.cs
@@ -14,5 +14,10 @@ namespace DotLiquid
         /// Behavior as of DotLiquid 2.1
         /// </summary>
         DotLiquid21 = 210,
+
+        /// <summary>
+        /// Behavior as of DotLiquid 2.2
+        /// </summary>
+        DotLiquid22 = 220,
     }
 }

--- a/src/DotLiquid/Tags/If.cs
+++ b/src/DotLiquid/Tags/If.cs
@@ -79,8 +79,8 @@ namespace DotLiquid.Tags
                 if (!syntaxMatch.Success)
                     throw new SyntaxException(SyntaxHelp);
 
-                Condition condition = new Condition(syntaxMatch.Groups[1].Value,
-                    syntaxMatch.Groups[2].Value, syntaxMatch.Groups[3].Value);
+                Condition condition = new Condition(syntaxMatch.Groups[1].Value.TrimStart('('),
+                    syntaxMatch.Groups[2].Value, syntaxMatch.Groups[3].Value.TrimEnd(')'));
 
                 var conditionCount = 1;
                 // continue to process remaining items in the list backwards, in pairs
@@ -97,8 +97,8 @@ namespace DotLiquid.Tags
                         throw new SyntaxException(TooMuchConditionsHelp);
                     }
 
-                    Condition newCondition = new Condition(expressionMatch.Groups[1].Value,
-                        expressionMatch.Groups[2].Value, expressionMatch.Groups[3].Value);
+                    Condition newCondition = new Condition(expressionMatch.Groups[1].Value.TrimStart('('),
+                        expressionMatch.Groups[2].Value, expressionMatch.Groups[3].Value.TrimEnd(')'));
                     switch (@operator)
                     {
                         case "and":

--- a/src/DotLiquid/Template.cs
+++ b/src/DotLiquid/Template.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -57,6 +58,7 @@ namespace DotLiquid
 
         private static readonly Dictionary<Type, Func<object, object>> SafeTypeTransformers;
         private static readonly Dictionary<Type, Func<object, object>> ValueTypeTransformers;
+        private static readonly ConcurrentDictionary<Type, Func<object, object>> ValueTypeTransformerCache;
 
         static Template()
         {
@@ -66,6 +68,7 @@ namespace DotLiquid
             Tags = new Dictionary<string, Tuple<ITagFactory, Type>>();
             SafeTypeTransformers = new Dictionary<Type, Func<object, object>>();
             ValueTypeTransformers = new Dictionary<Type, Func<object, object>>();
+            ValueTypeTransformerCache = new ConcurrentDictionary<Type, Func<object, object>>();
         }
 
         /// <summary>
@@ -181,6 +184,7 @@ namespace DotLiquid
         public static void RegisterValueTypeTransformer(Type type, Func<object, object> func)
         {
             ValueTypeTransformers[type] = func;
+            ValueTypeTransformerCache.Clear();
         }
 
         /// <summary>
@@ -195,16 +199,18 @@ namespace DotLiquid
                 return transformer;
 
             // Check for interfaces
-            var interfaces = type.GetTypeInfo().ImplementedInterfaces;
-            foreach (var interfaceType in interfaces)
+            return ValueTypeTransformerCache.GetOrAdd(type, (key) =>
             {
-                if (ValueTypeTransformers.TryGetValue(interfaceType, out transformer))
-                    return transformer;
-                if (interfaceType.GetTypeInfo().IsGenericType && ValueTypeTransformers.TryGetValue(
-                    interfaceType.GetGenericTypeDefinition(), out transformer))
-                    return transformer;
-            }
-            return null;
+                foreach (var interfaceType in type.GetTypeInfo().ImplementedInterfaces)
+                {
+                    if (ValueTypeTransformers.TryGetValue(interfaceType, out transformer))
+                        return transformer;
+                    if (interfaceType.GetTypeInfo().IsGenericType && ValueTypeTransformers.TryGetValue(interfaceType.GetGenericTypeDefinition(), out transformer))
+                        return transformer;
+                }
+
+                return null;
+            });
         }
 
         /// <summary>
@@ -234,12 +240,23 @@ namespace DotLiquid
         /// <summary>
         /// Creates a new <tt>Template</tt> object from liquid source code
         /// </summary>
-        /// <param name="source"></param>
+        /// <param name="source">The Liquid Template string</param>
         /// <returns></returns>
         public static Template Parse(string source)
         {
+            return Parse(source, Template.DefaultSyntaxCompatibilityLevel);
+        }
+
+        /// <summary>
+        /// Creates a new <tt>Template</tt> object from liquid source code
+        /// </summary>
+        /// <param name="source">The Liquid Template string</param>
+        /// <param name="syntaxCompatibilityLevel">The Liquid syntax flag used for backward compatibility</param>
+        /// <returns></returns>
+        public static Template Parse(string source, SyntaxCompatibility syntaxCompatibilityLevel)
+        {
             Template template = new Template();
-            template.ParseInternal(source);
+            template.ParseInternal(source, syntaxCompatibilityLevel);
             return template;
         }
 
@@ -298,14 +315,12 @@ namespace DotLiquid
         /// Returns self for easy chaining
         /// </summary>
         /// <param name="source">The source code.</param>
+        /// <param name="syntaxCompatibilityLevel">The Liquid syntax flag used for backward compatibility</param>
         /// <returns>The template.</returns>
-        internal Template ParseInternal(string source)
+        internal Template ParseInternal(string source, SyntaxCompatibility syntaxCompatibilityLevel)
         {
-            source = DotLiquid.Tags.Literal.FromShortHand(source);
-            source = DotLiquid.Tags.Comment.FromShortHand(source);
-
             this.Root = new Document();
-            this.Root.Initialize(tagName: null, markup: null, tokens: Template.Tokenize(source));
+            this.Root.Initialize(tagName: null, markup: null, tokens: Tokenizer.Tokenize(source, syntaxCompatibilityLevel));
             return this;
         }
 
@@ -438,16 +453,6 @@ namespace DotLiquid
                 if (!IsThreadSafe)
                     _errors = context.Errors;
             }
-        }
-
-        /// <summary>
-        /// Uses the <tt>Liquid::TemplateParser</tt> regexp to tokenize the passed source
-        /// </summary>
-        /// <param name="source"></param>
-        /// <returns></returns>
-        internal static List<string> Tokenize(string source)
-        {
-            return Tokenizer.Tokenize(source);
         }
     }
 }

--- a/src/DotLiquid/Tokenizer.cs
+++ b/src/DotLiquid/Tokenizer.cs
@@ -1,6 +1,5 @@
 using DotLiquid.Exceptions;
 using DotLiquid.Util;
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text;
@@ -13,31 +12,42 @@ namespace DotLiquid
     /// </summary>
     internal static class Tokenizer
     {
-        private static readonly HashSet<char> SearchSingleQuoteEnd = new HashSet<char> { '\'' };
-        private static readonly HashSet<char> SearchDoubleQuoteEnd = new HashSet<char> { '"' };
+        private static readonly HashSet<char> SearchVariableEnd = new HashSet<char> { '[', '.' };
+        private static readonly char BracketEnd = ']';
         private static readonly HashSet<char> SearchQuoteOrVariableEnd = new HashSet<char> { '}', '\'', '"' };
         private static readonly HashSet<char> SearchQuoteOrTagEnd = new HashSet<char> { '%', '\'', '"' };
+        private static readonly char[] WhitespaceCharsV20 = new char[] { '\t', ' ' };
+        private static readonly char[] WhitespaceCharsV22 = new char[] { '\t', '\n', '\v', '\f', '\r', ' ' };
         private static readonly Regex LiquidAnyStartingTagRegex = R.B(R.Q(@"({0})([-])?"), Liquid.AnyStartingTag);
         private static readonly Regex TagNameRegex = R.B(R.Q(@"{0}\s*(\w+)"), Liquid.AnyStartingTag);
+        private static readonly Regex VariableSegmentRegex = R.C(Liquid.VariableSegment);
         private static readonly ConcurrentDictionary<string, Regex> EndTagRegexes = new ConcurrentDictionary<string, Regex>();
 
         /// <summary>
         /// Splits a string into an array of `tokens` that represent either a tag, object/variable, or literal string
         /// </summary>
         /// <param name="source">The Liquid Template string</param>
-        /// <returns></returns>
+        /// <param name="syntaxCompatibilityLevel">The Liquid syntax flag used for backward compatibility</param>
         /// <exception cref="SyntaxException"></exception>
-        internal static List<string> Tokenize(string source)
+        internal static List<string> Tokenize(string source, SyntaxCompatibility syntaxCompatibilityLevel)
         {
             if (string.IsNullOrEmpty(source))
                 return new List<string>();
 
-            // Trim trailing whitespace.
-            source = Regex.Replace(source, string.Format(@"-({0}|{1})(\n|\r\n|[ \t]+)?", Liquid.VariableEnd, Liquid.TagEnd), "$1", RegexOptions.None, Template.RegexTimeOut);
+            // Trim leading whitespace - backward compatible list of chars
+            var whitespaceChars = syntaxCompatibilityLevel < SyntaxCompatibility.DotLiquid22 ? WhitespaceCharsV20 : WhitespaceCharsV22;
+
+            // Trim trailing whitespace - new lines or spaces/tabs but not both
+            if (syntaxCompatibilityLevel < SyntaxCompatibility.DotLiquid22)
+            {
+                source = DotLiquid.Tags.Literal.FromShortHand(source);
+                source = DotLiquid.Tags.Comment.FromShortHand(source);
+                source = Regex.Replace(source, string.Format(@"-({0}|{1})(\n|\r\n|[ \t]+)?", Liquid.VariableEnd, Liquid.TagEnd), "$1", RegexOptions.None, Template.RegexTimeOut);
+            }
 
             var tokens = new List<string>();
 
-            using (var markupEnumerator = new DotLiquid.Util.CharEnumerator(source))
+            using (var markupEnumerator = new CharEnumerator(source))
             {
                 var match = LiquidAnyStartingTagRegex.Match(source, markupEnumerator.Position);
                 while (match.Success)
@@ -47,20 +57,30 @@ namespace DotLiquid
                     {
                         var tokenBeforeMatch = ReadChars(markupEnumerator, match.Index - markupEnumerator.Position);
                         if (match.Groups[2].Success)
-                            tokenBeforeMatch = tokenBeforeMatch.TrimEnd(new char[] { '\t', ' ' });
+                            tokenBeforeMatch = tokenBeforeMatch.TrimEnd(whitespaceChars);
                         if (tokenBeforeMatch != string.Empty)
                             tokens.Add(tokenBeforeMatch);
                     }
 
                     var isTag = match.Groups[1].Value == "{%";
                     // Ignore hyphen in tag name, add the tag/variable itself
-                    var sb = new StringBuilder(markupEnumerator.Remaining);
-                    sb.Append(match.Groups[1].Value);
+                    var nextToken = new StringBuilder(markupEnumerator.Remaining);
+                    nextToken.Append(match.Groups[1].Value);
                     ReadChars(markupEnumerator, match.Length);
 
                     // Add the parameters and tag closure
-                    ReadToEnd(sb, markupEnumerator, isTag ? SearchQuoteOrTagEnd : SearchQuoteOrVariableEnd);
-                    var token = sb.ToString();
+                    if (isTag)
+                    {
+                        if (!ReadToEndOfTag(nextToken, markupEnumerator, SearchQuoteOrTagEnd, syntaxCompatibilityLevel))
+                            throw new SyntaxException(Liquid.ResourceManager.GetString("BlockTagNotTerminatedException"), nextToken.ToString(), Liquid.TagEnd);
+                    }
+                    else
+                    {
+                        if (!ReadToEndOfTag(nextToken, markupEnumerator, SearchQuoteOrVariableEnd, syntaxCompatibilityLevel))
+                            throw new SyntaxException(Liquid.ResourceManager.GetString("BlockVariableNotTerminatedException"), nextToken.ToString(), Liquid.VariableEnd);
+                    }
+
+                    var token = nextToken.ToString();
                     tokens.Add(token);
 
                     if (isTag)
@@ -91,12 +111,65 @@ namespace DotLiquid
         }
 
         /// <summary>
+        /// Enumerates over a variable sequence in dotted or bracket notation
+        /// </summary>
+        /// <param name="source">The Liquid Variable string</param>
+        /// <exception cref="SyntaxException"></exception>
+        internal static IEnumerator<string> GetVariableEnumerator(string source)
+        {
+            if (string.IsNullOrEmpty(source))
+                yield break;
+
+            using (var markupEnumerator = new CharEnumerator(source))
+            {
+                while (markupEnumerator.HasNext())
+                {
+                    var isComplete = false;
+                    var nextVariable = new StringBuilder();
+
+                    switch (markupEnumerator.Next)
+                    {
+                        case '[': // Example Syntax: [var] or ["literal"]
+                            markupEnumerator.AppendNext(nextVariable);
+                            if (!markupEnumerator.HasNext())
+                                break;
+
+                            switch (markupEnumerator.Next)
+                            {
+                                case '"':
+                                case '\'':
+                                    markupEnumerator.AppendNext(nextVariable);
+                                    isComplete = ReadToChar(nextVariable, markupEnumerator, markupEnumerator.Next) && ReadToChar(nextVariable, markupEnumerator, BracketEnd);
+                                    break;
+                                default:
+                                    isComplete = ReadToChar(nextVariable, markupEnumerator, BracketEnd);
+                                    break;
+                            }
+
+                            break;
+                        default:
+                            isComplete = ReadWordChar(nextVariable, markupEnumerator) && ReadToEndOfVariable(nextVariable, markupEnumerator);
+                            break;
+                    }
+
+                    if (!isComplete) // Somehow we reached the end without finding the end character(s)
+                        throw new SyntaxException(Liquid.ResourceManager.GetString("VariableNotTerminatedException"), source, Liquid.VariableEnd);
+
+                    if (markupEnumerator.HasNext() && markupEnumerator.Next == '.' && markupEnumerator.Remaining > 1)  // Don't include dot in tokens as it is a separator
+                        markupEnumerator.MoveNext();
+
+                    if (nextVariable.Length > 0)
+                        yield return nextVariable.ToString();
+                };
+            }
+        }
+
+        /// <summary>
         /// Reads a fixed number of characters and advances the enumerator position
         /// </summary>
         /// <param name="markupEnumerator">The string enumerator</param>
         /// <param name="markupLength">The number of characters to read</param>
-        /// <returns></returns>
-        private static string ReadChars(DotLiquid.Util.CharEnumerator markupEnumerator, int markupLength)
+        private static string ReadChars(CharEnumerator markupEnumerator, int markupLength)
         {
             var sb = new StringBuilder(markupLength);
             for (var i = 0; i < markupLength; i++)
@@ -107,15 +180,12 @@ namespace DotLiquid
         /// <summary>
         /// Reads a tag or object variable until the end sequence, <tt>%}</tt> or <tt>}}</tt> respectively and advances the enumerator position
         /// </summary>
-        /// <param name="sb">The string builder</param>
+        /// <param name="sb">The StringBuilder to write to</param>
         /// <param name="markupEnumerator">The string enumerator</param>
-        /// <param name="initialSearchChars">The character set to search for</param>
-        /// <exception cref="SyntaxException"></exception>
-        private static void ReadToEnd(StringBuilder sb, DotLiquid.Util.CharEnumerator markupEnumerator, HashSet<char> initialSearchChars)
+        /// <param name="searchChars">The character set to search for</param>
+        /// <returns>True if reaches end sequence, otherwise false</returns>
+        private static bool ReadToEndOfTag(StringBuilder sb, CharEnumerator markupEnumerator, HashSet<char> searchChars, SyntaxCompatibility syntaxCompatibilityLevel)
         {
-            var searchChars = initialSearchChars;
-            var isInQuotes = false;
-
             while (markupEnumerator.AppendNext(sb))
             {
                 char nextChar = markupEnumerator.Current;
@@ -124,32 +194,99 @@ namespace DotLiquid
                     switch (nextChar)
                     {
                         case '\'':
-                            isInQuotes = !isInQuotes;
-                            searchChars = isInQuotes ? SearchSingleQuoteEnd : initialSearchChars;
-                            break;
                         case '"':
-                            isInQuotes = !isInQuotes;
-                            searchChars = isInQuotes ? SearchDoubleQuoteEnd : initialSearchChars;
+                            ReadToChar(sb, markupEnumerator, nextChar);
                             break;
                         case '}':
                         case '%':
                             if (markupEnumerator.Remaining > 0 && markupEnumerator.Next == '}')
                             {
+                                var previousCharIsWhitespaceControl = syntaxCompatibilityLevel >= SyntaxCompatibility.DotLiquid22 && markupEnumerator.Previous == '-';
                                 markupEnumerator.AppendNext(sb);
-                                return;
+                                if (previousCharIsWhitespaceControl)
+                                {
+                                    // Remove hyphen from token
+                                    sb.Remove(sb.Length - 3, 1);
+
+                                    // Trim trailing whitespace by skipping ahead beyond the tag end
+                                    while (markupEnumerator.Remaining > 0)
+                                    {
+                                        if (((uint)markupEnumerator.Next - '\t') <= 5 || markupEnumerator.Next == ' ')
+                                            markupEnumerator.MoveNext();
+                                        else
+                                            break;
+                                    }
+                                }
+                                return true;
                             }
                             break;
                     }
                 }
             };
 
-            if (markupEnumerator.Remaining == 0) //Somehow we reached the end without finding the end character(s)
+            // Somehow we reached the end without finding the end character(s)
+            return false;
+        }
+
+        /// <summary>
+        /// Reads a token until, and inclusive of, the end character and advances the enumerator position
+        /// </summary>
+        /// <param name="sb">The StringBuilder to write to</param>
+        /// <param name="markupEnumerator">The string enumerator</param>
+        /// <param name="endChar">The character that indicates end of token</param>
+        /// <returns><see langword="true"/> if reaches <paramref name="endChar"/>, otherwise <see langword="false"/></returns>
+        private static bool ReadToChar(StringBuilder sb, CharEnumerator markupEnumerator, char endChar)
+        {
+            while (markupEnumerator.AppendNext(sb))
             {
-                if (initialSearchChars == SearchQuoteOrTagEnd)
-                    throw new SyntaxException(Liquid.ResourceManager.GetString("BlockTagNotTerminatedException"), sb.ToString(), Liquid.TagEnd);
-                else
-                    throw new SyntaxException(Liquid.ResourceManager.GetString("BlockVariableNotTerminatedException"), sb.ToString(), Liquid.VariableEnd);
+                if (markupEnumerator.Current == endChar)
+                    return true;
+            };
+
+            return false;
+        }
+
+        /// <summary>
+        /// Reads a token until the end of a variable segment and advances the enumerator position
+        /// </summary>
+        /// <param name="sb">The StringBuilder to write to</param>
+        /// <param name="markupEnumerator">The string enumerator</param>
+        /// <returns>True if valid variable, otherwise false</returns>
+        private static bool ReadToEndOfVariable(StringBuilder sb, CharEnumerator markupEnumerator)
+        {
+            while (markupEnumerator.HasNext())
+            {
+                var nextChar = markupEnumerator.Next;
+                if (SearchVariableEnd.Contains(nextChar))
+                    return true;
+
+                if (!ReadWordChar(sb, markupEnumerator))
+                    return false;
+            };
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a single word-character and advances the enumerator position
+        /// </summary>
+        /// <param name="sb">The StringBuilder to write to</param>
+        /// <param name="markupEnumerator">The string enumerator</param>
+        /// <returns>True if upcoming character is a word character, otherwise false</returns>
+        private static bool ReadWordChar(StringBuilder sb, CharEnumerator markupEnumerator)
+        {
+            var nextChar = markupEnumerator.Next;
+            if (nextChar < 128) // For better performance, avoid regex for standard ascii
+            {
+                if (!((uint)nextChar - '0' < 10 || (uint)nextChar - 'A' < 26 || (uint)nextChar - 'a' < 26 || nextChar == '_' || nextChar == '-'))
+                    return false;
             }
+            else if (!VariableSegmentRegex.IsMatch(nextChar.ToString()))
+            {
+                return false;
+            }
+
+            markupEnumerator.AppendNext(sb);
+            return true;
         }
     }
 }


### PR DESCRIPTION
* Updated Capitalize filter to be inline with Reference Library.

* Idea discussed and originally developed by @robin-parker

* Render performance rewrite

* Whitespace control handling changes, resolves #411

* Remove non-standard short-hand notation for comments and literal tags. See https://github.com/Shopify/liquid/commit/f85bea290205578b0037d86f62e3abebf6745f38

* PR code review changes to syntax - no functional changes

* Address PR review + additional code coverage

* Resolves #413

* Implements SortNatural Filter and changes Sort to be case-sensitive in line with spec

* Code formatting changes per PR review